### PR TITLE
Fix an issue that made Jekyll build process fail

### DIFF
--- a/lib/jekyll-index-pages/author.rb
+++ b/lib/jekyll-index-pages/author.rb
@@ -4,7 +4,8 @@ module JekyllIndexPages
 
     def generate(site)
       authors = Hash.new { |hash, key| hash[key] = [] }
-      site.posts.docs.each { |doc| authors[doc.data["author"]] << doc }
+      authored_docs = site.posts.docs.select { |doc| doc.data.key?("author") }
+      authored_docs.each { |doc| authors[doc.data["author"]] << doc }
       site.data["authors"] = authors
     end
   end

--- a/spec/fixtures/index-page/_posts/1987-09-28-star-trek-the-next-generation-no-author.md
+++ b/spec/fixtures/index-page/_posts/1987-09-28-star-trek-the-next-generation-no-author.md
@@ -1,0 +1,7 @@
+---
+title: "Star Trek: The Next Generation"
+category: Science fiction
+tags: star-trek
+---
+
+# Star Trek: The Next Generation

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -49,8 +49,8 @@ describe JekyllIndexPages::Generator do
         expect(site.pages[0].data["pager"]).to be_instance_of(Hash)
       end
 
-      it "generates a post index page with six documents" do
-        expect(site.pages[0].data["pager"]["docs"].length).to eq(6)
+      it "generates a post index page with seven documents" do
+        expect(site.pages[0].data["pager"]["docs"].length).to eq(7)
       end
 
       it "generates a post index page with recent documents first" do
@@ -67,10 +67,13 @@ describe JekyllIndexPages::Generator do
         expect(fourth.date).to eq(Time.new(1987, 9, 28))
 
         fifth = site.pages[0].data["pager"]["docs"][4]
-        expect(fifth.date).to eq(Time.new(1966, 9, 8))
+        expect(fifth.date).to eq(Time.new(1987, 9, 28))
 
         sixth = site.pages[0].data["pager"]["docs"][5]
         expect(sixth.date).to eq(Time.new(1966, 9, 8))
+
+        seventh = site.pages[0].data["pager"]["docs"][6]
+        expect(seventh.date).to eq(Time.new(1966, 9, 8))
       end
     end
   end
@@ -152,8 +155,38 @@ describe JekyllIndexPages::Generator do
       context "generates the third post index page" do
         let(:page) { site.pages[2] }
 
-        it "with previous page url only" do
+        it "with two documents" do
+          expect(page.data["pager"]["docs"].length).to eq(2)
+        end
+
+        it "sorted by date, recent first" do
+          first = page.data["pager"]["docs"][0]
+          expect(first.date).to eq(Time.new(1987, 9, 28))
+
+          second = page.data["pager"]["docs"][1]
+          expect(second.date).to eq(Time.new(1966, 9, 8))
+        end
+
+        it "with previous and next page urls" do
           expect(page.data["pager"]["prev_page_url"]).to eq("/posts/2/")
+          expect(page.data["pager"]["next_page_url"]).to eq("/posts/4/")
+        end
+      end
+
+      context "generates the fourth post index page" do
+        let(:page) { site.pages[3] }
+
+        it "with one document" do
+          expect(page.data["pager"]["docs"].length).to eq(1)
+        end
+
+        it "sorted by date, recent first" do
+          first = page.data["pager"]["docs"][0]
+          expect(first.date).to eq(Time.new(1966, 9, 8))
+        end
+
+        it "with previous page url only" do
+          expect(page.data["pager"]["prev_page_url"]).to eq("/posts/3/")
           expect(page.data["pager"]["next_page_url"]).to eq("")
         end
       end

--- a/spec/index-page_spec.rb
+++ b/spec/index-page_spec.rb
@@ -58,7 +58,7 @@ describe JekyllIndexPages::IndexPage do
         end
 
         it "containing pagination data" do
-          expect(page.data["pager"]["total_pages"]).to eq(3)
+          expect(page.data["pager"]["total_pages"]).to eq(4)
           expect(page.data["pager"]["current_page"]).to eq(1)
           expect(page.data["pager"]["prev_page"]).to eq(0)
           expect(page.data["pager"]["next_page"]).to eq(2)
@@ -92,6 +92,19 @@ describe JekyllIndexPages::IndexPage do
 
         it "containing url for prev page only" do
           expect(page.data["pager"]["prev_page_url"]).to eq("/posts/2/")
+          expect(page.data["pager"]["next_page_url"]).to eq("/posts/4/")
+        end
+      end
+
+      context "creates the fourth index page" do
+        let(:dir) { "/posts/4" }
+        let(:pager) do
+          pagination.paginate(3)
+          pagination.pager
+        end
+
+        it "containing url for prev page only" do
+          expect(page.data["pager"]["prev_page_url"]).to eq("/posts/3/")
           expect(page.data["pager"]["next_page_url"]).to eq("")
         end
       end


### PR DESCRIPTION
Jekyll build process was failing when no author is specified in posts.